### PR TITLE
fix bug in queryResultData when query fails with error

### DIFF
--- a/sqlutils/sqlutils.go
+++ b/sqlutils/sqlutils.go
@@ -223,7 +223,9 @@ func queryResultData(db *sql.DB, query string, retrieveColumns bool, args ...int
 
 	columns := []string{}
 	rows, err := db.Query(query, args...)
-	defer rows.Close()
+	if rows != nil {
+    defer rows.Close()
+  }
 	if err != nil && err != sql.ErrNoRows {
 		return EmptyResultData, columns, log.Errore(err)
 	}

--- a/sqlutils/sqlutils.go
+++ b/sqlutils/sqlutils.go
@@ -21,11 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/openark/golib/log"
 	"strconv"
 	"strings"
 	"sync"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/openark/golib/log"
 )
 
 // RowMap represents one row in a result set. Its objective is to allow
@@ -224,8 +225,8 @@ func queryResultData(db *sql.DB, query string, retrieveColumns bool, args ...int
 	columns := []string{}
 	rows, err := db.Query(query, args...)
 	if rows != nil {
-    defer rows.Close()
-  }
+		defer rows.Close()
+	}
 	if err != nil && err != sql.ErrNoRows {
 		return EmptyResultData, columns, log.Errore(err)
 	}


### PR DESCRIPTION
There can be cases, when our query will return error, so rows will be nil. So if we don't add if statement, we will get errors in defer rows.Close()