### PR TITLE
queryResultData: do not log twice, just return the error to caller

### DIFF
--- a/sqlutils/sqlutils.go
+++ b/sqlutils/sqlutils.go
@@ -225,7 +225,7 @@ func queryResultData(db *sql.DB, query string, retrieveColumns bool, args ...int
 	rows, err := db.Query(query, args...)
 	defer rows.Close()
 	if err != nil && err != sql.ErrNoRows {
-		return EmptyResultData, columns, log.Errore(err)
+		return EmptyResultData, columns, err
 	}
 	if retrieveColumns {
 		// Don't pay if you don't want to


### PR DESCRIPTION
Step 1 to fix stuff like the following seen in orchestrator logging:

```
2018-11-24T19:24:04.026091+01:00 orchestratorapp orchestrator[59561]: Error 1146: Table 'mydb.pseudo_gtid_status' doesn't exist
2018-11-24T19:24:04.027256+01:00 orchestratorapp orchestrator[59561]: 2018-11-24 19:24:04 ERROR Error 1146: Table 'mydb.pseudo_gtid_status' doesn't exist
2018-11-24T19:24:04.027352+01:00 orchestratorapp orchestrator[59561]: 2018-11-24 19:24:04 ERROR ReadTopologyInstance(somehost:3306:3306) DetectPseudoGTIDQuery: Error 1146: Table 'mydb.pseudo_gtid_status' doesn't exist
```

This needs to be logged once and not in 3 places.
This specific patch fixes the issue of the most downstream call being logged when the error is being passed (and used) by the caller.