### PR TITLE
Report function name correctly

### DIFF
--- a/sqlutils/sqlutils.go
+++ b/sqlutils/sqlutils.go
@@ -217,7 +217,7 @@ func queryResultData(db *sql.DB, query string, retrieveColumns bool, args ...int
 	var err error
 	defer func() {
 		if derr := recover(); derr != nil {
-			err = errors.New(fmt.Sprintf("QueryRowsMap unexpected error: %+v", derr))
+			err = errors.New(fmt.Sprintf("queryResultData unexpected error: %+v", derr))
 		}
 	}()
 


### PR DESCRIPTION
Minor tweak. The error message was reporting the wrong function name.