### PR TITLE
remove package dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module github.com/openark/golib
 
 go 1.16
-
-require (
-	github.com/go-sql-driver/mysql v1.6.0
-	github.com/mattn/go-sqlite3 v1.14.7
-)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
-github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
-github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/sqlutils/sqlutils.go
+++ b/sqlutils/sqlutils.go
@@ -26,8 +26,6 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/openark/golib/log"
 )
 


### PR DESCRIPTION
This PR removes imports for `github.com/mattn/go-sqlite3` and `github.com/go-sql-driver/mysql` ; they are not directly used by this repo and they create overhead when importing this repo.

The `import`s were organically added when this library was used internally at `orchestrator`. But now it's external, `orchestrator` will do its own explicit imports (see https://github.com/openark/orchestrator/pull/1361)